### PR TITLE
fix(issue events): assignees may be undefined

### DIFF
--- a/app/service/webhook.js
+++ b/app/service/webhook.js
@@ -220,7 +220,7 @@ class WebhookService extends Service {
     return content
   }
 
-  async assembleIssueMsq(content, { user, project, repository, object_attributes, assignees, assignee, labels }) {
+  async assembleIssueMsq(content, { user, project, repository, object_attributes, assignees = [], assignee, labels }) {
     const { id: issueId, title, state, action, description, url: issueUrl } = object_attributes || {};
     const { name: projName, web_url, path_with_namespace } = project || {};
     const { name, username } = user || {};


### PR DESCRIPTION
在 gitlab-13.5.3-ee 中测试发现 issue 类型事件中，assignees 不指定的情况下为 undefined